### PR TITLE
chore: Pin GitHub Actions to SHAs (COM-3904 migration)

### DIFF
--- a/.github/workflows/label-merge-block.yml
+++ b/.github/workflows/label-merge-block.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for Block Label
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
             const labelToBlock = 'DO_NOT_MERGE'; // ブロックしたいラベル名を指定


### PR DESCRIPTION
## Summary
GitHub Actions の `uses:` 行を SHA pin + バージョンコメント形式に変換します。
COM-3904 (parent: COM-3890) の段階 1 migration の自動生成 PR です。

## 変更内容 (third-party: 約 1 行, same-org: 0 行)
(third-party のみ。詳細は diff を確認)

## 関連
- Linear: COM-3904
- ADR / TDD: toridori-docs-agent#662

> Generated by actions-migration script (COM-3904)