### PR TITLE
chore: add actions-policy caller workflow (COM-3907)

### DIFF
--- a/.github/workflows/actions-policy.yml
+++ b/.github/workflows/actions-policy.yml
@@ -1,0 +1,14 @@
+name: Actions policy
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  actions-policy:
+    uses: toridori-inc/toridori-github-actions/.github/workflows/actions-policy.yml@main


### PR DESCRIPTION
## Summary
Adds `.github/workflows/actions-policy.yml` caller for the org-wide GitHub Actions policy CI (COM-3907 / parent COM-3890).

The status check `actions-policy / pinact` will be reported on every PR. It becomes a required check in Phase 5 (COM-3908).

The `ci/skip-actions-policy` label provides an emergency bypass — applying it makes the workflow skip pinact checks while still reporting success.

## Related
- Linear: COM-3907
- ADR / TDD: toridori-docs-agent (actions_policy_enforcement)

> Generated by deploy-caller (COM-3907)